### PR TITLE
load bs-php-utils from right location

### DIFF
--- a/accesscontrol/ACL/ACLGuard.php
+++ b/accesscontrol/ACL/ACLGuard.php
@@ -8,7 +8,7 @@ include_once __DIR__ . '/RoleAssignment.php';
 include_once __DIR__ . '/CrudPermission.php';
 include_once __DIR__ . '/Permission.php';
 include_once __DIR__ . '/JwtBlackList.php';
-include_once __DIR__ . '/../../../bs-php-utils/utils.php';
+include_once __DIR__ . '/../../../../bensteffen/bs-php-utils/utils.php';
 
 class ACLGuard extends Guard {
     protected $acModel;

--- a/database/FilterParser.php
+++ b/database/FilterParser.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once __DIR__ . "/../../bs-php-utils/utils.php";
+include_once __DIR__ . "/../../../bensteffen/bs-php-utils/utils.php";
 include_once __DIR__ . '/../requestutils/url.php';
 include_once __DIR__ . '/query.php';
 

--- a/database/SqlConnection.php
+++ b/database/SqlConnection.php
@@ -2,7 +2,7 @@
 
 include_once __DIR__ . "/IfDatabseConnection.php";
 include_once __DIR__ . "/SqlQueryFactory.php";
-include_once __DIR__ . '/../../bs-php-utils/utils.php';
+include_once __DIR__ . '/../../../bensteffen/bs-php-utils/utils.php';
 
 class SqlConnection implements IfDatabseConnection {
     private $dbConnection = null;

--- a/database/SqlQueryFactory.php
+++ b/database/SqlQueryFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 include_once __DIR__ . '/sql.php';
-include_once __DIR__ . '/../../bs-php-utils/utils.php';
+include_once __DIR__ . '/../../../bensteffen/bs-php-utils/utils.php';
 
 class SqlQueryFactory {
     public static function makeCreateQuery($entity) {

--- a/database/query.php
+++ b/database/query.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once __DIR__ . '/../../bs-php-utils/utils.php';
+include_once __DIR__ . '/../../../bensteffen/bs-php-utils/utils.php';
 
 abstract class QueryElement {
     protected $creator;

--- a/database/sql.php
+++ b/database/sql.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once __DIR__ . '/../../bs-php-utils/utils.php';
+include_once __DIR__ . '/../../../bensteffen/bs-php-utils/utils.php';
 include_once __DIR__ . '/query.php';
 
 

--- a/datamodel/DataEntity.php
+++ b/datamodel/DataEntity.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once __DIR__ . '/../../bs-php-utils/utils.php';
+include_once __DIR__ . '/../../../bensteffen/bs-php-utils/utils.php';
 
 class DataEntity {
     protected $name;

--- a/datamodel/DataModel.php
+++ b/datamodel/DataModel.php
@@ -2,9 +2,9 @@
 
 include_once __DIR__ . "/../FlexAPI.php";
 include_once __DIR__ . "/DataReferenceSet.php";
-include_once __DIR__ . "/../../bs-php-utils/Options.php";
+include_once __DIR__ . "/../../../bensteffen/bs-php-utils/Options.php";
 include_once __DIR__ . "/../accesscontrol/WorstGuardAtAll.php";
-include_once __DIR__ . "/../../bs-php-utils/utils.php";
+include_once __DIR__ . "/../../../bensteffen/bs-php-utils/utils.php";
 
 class DataModel {
     protected $connection = null;

--- a/datamodel/DataReferenceSet.php
+++ b/datamodel/DataReferenceSet.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once __DIR__ . "/../../bs-php-utils/utils.php";
+include_once __DIR__ . "/../../../bensteffen/bs-php-utils/utils.php";
 
 class DataReferenceSet {
 

--- a/requestutils/url.php
+++ b/requestutils/url.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once __DIR__ . "/../../bs-php-utils/utils.php";
+include_once __DIR__ . "/../../../bensteffen/bs-php-utils/utils.php";
 
 function parseArrayString($str) {
     if (preg_match("/^\[.*\]$/", $str)) {

--- a/upload.php
+++ b/upload.php
@@ -2,7 +2,7 @@
 
 include_once __DIR__ . '/FlexAPI.php';
 include_once __DIR__ . '/requestutils/jwt.php';
-include_once __DIR__ . '/../bs-php-utils/utils.php';
+include_once __DIR__ . '/../../bensteffen/bs-php-utils/utils.php';
 
 try {
 


### PR DESCRIPTION
This is not a decent fix. Ideally it would be auto-discovered. From what I can tell this requires support on side of the library being loaded. I'm not even sure if a function collection (i.e. no class) is supported to be auto-loaded.

With this patch I can at least get the adfc-t30-api running again:
```
# apt install composer
composer install
php -S localhost:3000

curl 'localhost:3000/api/crud.php?entity=institution'
```