### PR TITLE
Neuer Query-Parameter "nores"

### DIFF
--- a/crud.php
+++ b/crud.php
@@ -27,12 +27,13 @@ function flexapiCrud() {
         switch ($method) {
             case 'GET':
                 $response = FlexAPI::dataModel()->read($parameters['entity'], [
-                    'filter'     => $parameters['filter'],
-                    'references' => $parameters['refs'],
-                    'selection'  => $parameters['select'],
-                    'flatten'    => $parameters['flatten'],
-                    'sort'       => $parameters['sort'],
-                    'pagination' => $parameters['pages']
+                    'filter'      => $parameters['filter'],
+                    'references'  => $parameters['refs'],
+                    'selection'   => $parameters['select'],
+                    'flatten'     => $parameters['flatten'],
+                    'emptyResult' => $parameters['nores'],
+                    'sort'        => $parameters['sort'],
+                    'pagination'  => $parameters['pages']
                 ]);
                 break;
             case 'POST':

--- a/requestutils/url.php
+++ b/requestutils/url.php
@@ -99,15 +99,22 @@ function parseUrlParameters($queries) {
         }
     }
 
+    if (array_key_exists('nores', $queries)) {
+        $noresult = json_decode($queries['nores']);
+    } else {
+        $noresult = null;
+    }
+
     return [
-        'do'      => $do,
-        'entity'  => $entityName,
-        'filter'  => $filter,
-        'select'  => $select,
-        'refs'    => $refs,
-        'flatten' => $flatten,
-        'sort'    => $sort,
-        'pages'   => $pages
+        'do'       => $do,
+        'entity'   => $entityName,
+        'filter'   => $filter,
+        'select'   => $select,
+        'refs'     => $refs,
+        'flatten'  => $flatten,
+        'nores'    => $noresult,
+        'sort'     => $sort,
+        'pages'    => $pages
     ];
 }
 


### PR DESCRIPTION
gibt an, welcher Wert zurück gegeben wird, wenn das Result-Set leer ist.
Beispiel: nores=[] // gibt leeres Array zurück