### PR TITLE
Setze SELECT DISTINCT auf false

### DIFF
--- a/accesscontrol/ACL/ACLGuard.php
+++ b/accesscontrol/ACL/ACLGuard.php
@@ -294,7 +294,7 @@ class ACLGuard extends Guard {
 
     public function readPermitted($connection, $entity, $filter, $selection, $sort, $onlyOwn = false) {
         $filter = $this->addPermissionFilter('R', $entity, $filter, $onlyOwn);
-        return $connection->readFromDataBase($entity, $filter, $selection, true, $sort);
+        return $connection->readFromDataBase($entity, $filter, $selection, false, $sort);
     }
 
     public function updatePermitted($connection, $entity, $filter, $data) {

--- a/datamodel/DataModel.php
+++ b/datamodel/DataModel.php
@@ -224,7 +224,7 @@ class DataModel {
         if ($this->guard->permissionsNeeded($entityName)) {
             $data = $this->guard->readPermitted($this->connection, $entity, $filter, $regularSelection, $sort);
         } else {
-            $data = $this->connection->readFromDatabase($entity, $filter, $regularSelection, true, $sort, $pagination);
+            $data = $this->connection->readFromDatabase($entity, $filter, $regularSelection, false, $sort, $pagination);
         }
 
         $this->notifyObservers([


### PR DESCRIPTION
Rührt noch von einer Version, in der die Berechtigungen per JOIN in einen Request eingebunden wurden. Da es jetzt über WHERE geht, sollte DISTINCT obsolet sein.