### PR TITLE
Portal-Funktion "extendLogin"

### DIFF
--- a/portal.php
+++ b/portal.php
@@ -25,6 +25,10 @@ function flexapiPortal() {
                 $request = [ 'concern' => 'passwordChange', 'token' => $_GET['passwordChange'] ];
                 $methodOk = true;
             }
+            if (array_key_exists('extendLogin', $_GET)) {
+                $request = [ 'concern' => 'extendLogin' ];
+                $methodOk = true;
+            }
         } elseif ($method === 'POST') {
             $methodOk = true;
         }
@@ -40,6 +44,13 @@ function flexapiPortal() {
                 "token" => $token,
             ];
         // TODO: add concern "verify (registration)"
+        } elseif ($request["concern"] === "extendLogin") {
+            $jwt = getJWT();
+            $jwt = FlexAPI::guard()->extendLogin($jwt);
+            $response = [
+                "message" => "Extension successfull",
+                "token" => $jwt
+            ];
         } elseif ($request["concern"] === "logout") {
             FlexAPI::guard()->logout(getJWT());
             $response = ["message" => "Logout sucessfull"];


### PR DESCRIPTION
Mit vorhandenem gültigen JWT kann man sich einen neuen JWT erzeugen lassen. Aus technischen Gründen kann der alte JWT nicht "verlängert" werden, sondern es muss ein neuer JWT erzeugt werden.

Aufrufmöglichkeit 1:
POST /portal.php
``` json
{ "concern": "extendLogin" }
```

Aufrufmöglichkeit 2:
GET /portal.php?extendLogin

Dabei befindet sich der alte JWT wie gewohnt im Request-Header "Access-Control-Allow-Credentials"


## Beispiel
 Lautet die Einstellung     ![image](https://user-images.githubusercontent.com/37374938/64712543-b27cb180-d4bb-11e9-9b15-23d0248c181f.png)

so ist das Ergebnis von extendLogin beim Aufrufzeitpunkt

 * 600 s vor Ablauf des alten JWT der alte JWT selbst
 * nach Ablauf des alten JWT der Fehler "expired token"
 * dazwischen ein um 10 Minuten verlängerter JWT


## Anderer Vorschlag

So richtig glücklich macht mich die "Verlängerung" JWTs irgendwie nicht. Das entspricht so richtig der typischen Verwendung von JWTs, bei der Server-seitig keine Session-Information gespeichert wird. Da die ein Schwenk von JWT auf Session-Id leider nicht trivial möglich ist mache ich mal folgenden Vorschlag:

Der kann bei der Anmeldung eine Box "angemeldet bleiben" anhakeln.  Falls sie angehakelt ist (Fall 1), steht dabei der erklärende Text "Anmeldung bleibt für xy gültig auch wenn währenddessen der Browser oder der Browser-Tab geschlossen und wieder geöffnet wird". Falls es nicht angehakelt ist (Fall 2) erscheint der erklärende Text "Anmeldung bleibt xy gültig oder bis der Browser oder der Browser-Tab geschlossen wird."

xy entspricht der API-Konfig "jwtValidityDuration". Über einen guten Wert können wir diskutieren, ich schlage mal 24 Stunden vor.

Im Fall1 (so ist jetzt derzeit im Frontend, hab ich gesehen) wird der JWT im localStorage des Browsers gespeichert. Wenn die Seite geschlossen und wieder aufgerufen wird, wird außerdem geprüft ob sich im localStorage ein noch gültiger JWT befindet. Falls nicht Weiterleitung zur Login-Seite. Falls der User schon vor dem Ablauf von xy Stunden die Anmeldung ungültig machen will gibt es ja die logout-Funktion, die den JWT in einer Black-List speichert.

Im Fall2 wird der JWT im sessionStorage gespeichert (bleibt bei Refresh bestehen, wird beim schließen eines Tabs aber geleert). Beim Wiederaufruf wird kein JWT gefunden und es geht zur Login-Seite.

 



