### PR TITLE
Neu: onlyOwn Flag

### DIFF
--- a/accesscontrol/ACL/ACLGuard.php
+++ b/accesscontrol/ACL/ACLGuard.php
@@ -310,7 +310,7 @@ class ACLGuard extends Guard {
 
     public function readPermitted($connection, $entity, $filter, $selection, $sort, $onlyOwn = false) {
         $filter = $this->addPermissionFilter('R', $entity, $filter, $onlyOwn);
-        return $connection->readFromDataBase($entity, $filter, $selection, false, $sort);
+        return $connection->readFromDataBase($entity, $filter, $selection, $onlyOwn, $sort);
     }
 
     public function updatePermitted($connection, $entity, $filter, $data) {
@@ -357,6 +357,7 @@ class ACLGuard extends Guard {
             new QueryValue($this->getUsername())
         );
 
+        $onlyOwn = true;
         if (!$onlyOwn) {
             $userRoles = $this->getUserRoles();
             if (count($userRoles) > 0) {

--- a/crud.php
+++ b/crud.php
@@ -33,7 +33,8 @@ function flexapiCrud() {
                     'flatten'     => $parameters['flatten'],
                     'emptyResult' => $parameters['nores'],
                     'sort'        => $parameters['sort'],
-                    'pagination'  => $parameters['pages']
+                    'pagination'  => $parameters['pages'],
+                    'onlyOwn'     => $parameters['onlyOwn'],
                 ]);
                 break;
             case 'POST':

--- a/requestutils/url.php
+++ b/requestutils/url.php
@@ -105,6 +105,12 @@ function parseUrlParameters($queries) {
         $noresult = null;
     }
 
+    if (array_key_exists('onlyOwn', $queries)) {
+        $onlyOwn = true;
+    } else {
+        $onlyOwn = false;
+    }
+
     return [
         'do'       => $do,
         'entity'   => $entityName,
@@ -114,7 +120,8 @@ function parseUrlParameters($queries) {
         'flatten'  => $flatten,
         'nores'    => $noresult,
         'sort'     => $sort,
-        'pages'    => $pages
+        'pages'    => $pages,
+        'onlyOwn'  => $onlyOwn
     ];
 }
 


### PR DESCRIPTION
Gibt nur Resourcen, für die man explizit einen Eintrag in der Permission-Tabelle hat, zurück.

wenn man z.B. als Admin angemeldet ist wird

GET /crud.php?entity=userdata 

alle Userdaten zurück liefern und

GET /crud.php?entity=userdata&onlyOwn

nur die eigenen.

