### PR TITLE
Lower Packagename

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ADFC-Hamburg/flexapi",
+  "name": "adfc-hamburg/flexapi",
   "repositories": {
     "bs-php-utils": {
       "type": "package",


### PR DESCRIPTION
Compsoer 2.0 mag keine Großbuchstaben. Ungetestet. Würde ich testen, wenn ich beide Pull-Requests mergen kann