### PR TITLE
check permission BEFORE resolving a reference

### DIFF
--- a/datamodel/DataModel.php
+++ b/datamodel/DataModel.php
@@ -437,11 +437,15 @@ class DataModel {
         if ($config['format'] === "key") {
             $content = $referenceId;
         } elseif ($config['format'] === "data") {
-            $content = $this->read($reference['referencedEntity'], [
-                'references' => $config,
-                'filter' => [$referenceIdName => $referenceId],
-                'flatten' => 'singleResult'
-            ]);
+            if ($this->guard->userMay('read', $reference['referencedEntity'])) {
+                $content = $this->read($reference['referencedEntity'], [
+                    'references' => $config,
+                    'filter' => [$referenceIdName => $referenceId],
+                    'flatten' => 'singleResult'
+                ]);
+            } else {
+                $content = $referenceId;
+            }
         } elseif ($config['format'] === "url") {
             $content = $this->makeResourceUrl($reference['referencedEntity'], $referenceIdName, $referenceId);
         }


### PR DESCRIPTION
Verhindert Abbruch der Referenz-Auflösung, falls für eine Referenz Lesen nicht erlaubt ist.